### PR TITLE
Additional exposed port 9090

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,4 @@ RUN chmod -v +x /etc/service/*/run /etc/my_init.d/*.sh
 
 # set the volume and ports
 VOLUME /config/.kodi
-EXPOSE 8080 9777/udp
-
-
+EXPOSE 8080 9777/udp 9090 5353/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ RUN chmod -v +x /etc/service/*/run /etc/my_init.d/*.sh
 
 # set the volume and ports
 VOLUME /config/.kodi
-EXPOSE 8080 9777/udp 9090 5353/udp
+EXPOSE 8080 9777/udp 9090

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ docker create --name=kodi-headless \
 -v <path to data>:/config/.kodi \
 -e PGID=<gid> -e PUID=<uid> \
 -e VERSION=<version> -e TZ=<timezone> \
--p 8080:8080 -p 9777:9777/udp \
+-p 8080:8080 -p 9090:9090 -p 9777:9777/udp \
 linuxserver/kodi-headless
 ```
 
 **Parameters**
 
 * `-p 8080` - webui port
+* `-p 9090` - JSON-RPC TCP port *optional*, e.g. FileBot use it to send commands
 * `-p 9777/udp` - esall interface port
 * `-v /config/.kodi` - path for kodi configuration files
 * `-e PGID` for GroupID - see below for explanation
@@ -60,6 +61,7 @@ If you intend to use this kodi instance to perform library tasks other than mere
 Various members of the xbmc/kodi community for patches and advice.
 
 ## Versions
++ **29.05.2016:** Additional exposed port: 9090 TCP for JSON-RPC
 + **13.03.2016:** Make kodi 16 (jarvis) default installed version.
 + **21.08.2015:** Initial Release.
 


### PR DESCRIPTION
Exposed port 9090 to have the possibility to use JSON-RPC over TCP which will be used for example by the application FileBot to communicate with Kodi. README.md is updated too.
Change was tested on my Synology DS415+ and the image is available at Docker Hub too - https://hub.docker.com/r/technosoft2000/kodi-headless/

Would be great if you accept this change :)