### PR TITLE
add kodi send executable and module to correct place

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,12 +184,12 @@ RUN \
  make install && \
 
 # install kodi-send
- install -Dm644 \
+ install -Dm755 \
 	/tmp/kodi-source/tools/EventClients/Clients/Kodi\ Send/kodi-send.py \
 	/usr/bin/kodi-send && \
  install -Dm644 \
 	/tmp/kodi-source/tools/EventClients/lib/python/xbmcclient.py \
-	/usr/share/kodi/system/python/xbmcclient.py && \
+	/usr/lib/python2.7/xbmcclient.py && \
 
 # cleanup build dependencies
  apk del --purge \
@@ -235,4 +235,3 @@ COPY root/ /
 # ports and volumes
 VOLUME /config/.kodi
 EXPOSE 8080 9777/udp
-

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Various members of the xbmc/kodi community for patches and advice.
 
 ## Versions
 
++ **20.09.16:** Add kodi-send and fix var cache samba permissions.
 + **10.09.16:** Add layer badge to README..
 + **02.09.16:** Rebase to alpine linux.
 + **13.03.16:** Make kodi 16 (jarvis) default installed version.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io


+ Make kodi-send executable and put xbmclient.py in correct place.
+ kodi-send "should" work now.
+ No extra files to download as kodi-send and the xbmclient.py module already in the git tar used to build main package.