### PR TITLE
Port 9090 is now used for websockets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,4 +185,4 @@ COPY root/ /
 
 # ports and volumes
 VOLUME /config/.kodi
-EXPOSE 8080 9777/udp
+EXPOSE 8080 9090 9777/udp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

