### PR TITLE
bump leia to release, keep krypton as default for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Add one of the tags,  if required,  to the linuxserver/kodi-headless line of the
 + **Isengard**
 + **Jarvis**
 + **Krypton** : current default branch.
++ **Leia**
 
 
 **Parameters**
@@ -84,6 +85,7 @@ Various members of the xbmc/kodi community for patches and advice.
 
 ## Versions
 
++ **30.01.19:** Bump Leia branch to release ppa.
 + **03.09.18:** Add back libnfs dependency.
 + **31.08.18:** Rebase to ubuntu bionic, use buildstage and add info about websockets port.
 + **04.01.18:** Deprecate cpu_core routine lack of scaling.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ Adds tag for Leia to readme. 
+ Keep krypton as the default tag for the moment.
+ Leia doesn't require the headless patch
+ it seems to hit cpu damn hard when updating library.