### PR TITLE
Proposal for a lighter headless kodi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM lsiobase/ubuntu:bionic as buildstage
 ############## build stage ##############
 
 # package versions
-ARG KODI_NAME="Krypton"
-ARG KODI_VER="17.6"
+ARG KODI_NAME="Leia"
+ARG KODI_VER="18.1"
+
+### synology workaround ###
+ENV KODI_NAME=$KODI_NAME
+ENV KODI_VER=$KODI_VER
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -15,86 +19,28 @@ COPY excludes /etc/dpkg/dpkg.cfg.d/excludes
 RUN \
  echo "**** install build packages ****" && \
  apt-get update && \
- apt-get install -y \
-	ant \
-	autoconf \
-	automake \
-	autopoint \
-	binutils \
-	cmake \
-	curl \
-	default-jdk \
-	doxygen \
-	g++ \
-	gawk \
-	gcc \
-	git-core \
-	gperf \
-	libass-dev \
-	libavahi-core-dev\
-	libbluray-dev \
-	libboost1.65-dev \
-	libbz2-ocaml-dev \
-	libcap-dev \
-	libcurl4-openssl-dev \
-	libegl1-mesa-dev \
-	libflac-dev \
-	libfmt-dev \
-	libfreetype6-dev \
-	libgif-dev \
-	libgle3-dev \
-	libglew-dev \
-	libiso9660-dev \
-	libjpeg-dev \
-	liblcms2-dev \
-	liblzo2-dev \
-	libmicrohttpd-dev \
-	libmpeg2-4-dev \
-	libmysqlclient-dev \
-	libnfs-dev \
-	libpcre3-dev \
-	libplist-dev \
-	libsmbclient-dev \
-	libsndio-dev \
-	libsqlite3-dev \
-	libssh-dev \
-	libtag1-dev \
-	libtiff5-dev \
-	libtinyxml-dev \
-	libtool \
-	libva-dev \
-	libvdpau-dev \
-	libvorbis-dev \
-	libxml2-dev \
-	libxrandr-dev \
-	libxslt-dev \
-	libyajl-dev \
-	m4 \
-	make \
-	python-dev \
-	rapidjson-dev \
-	swig \
-	uuid-dev \
-	yasm \
-	zip
-
+ apt-get install -y software-properties-common && \
+ add-apt-repository -s ppa:team-xbmc/xbmc-nightly && \
+ apt-get -y build-dep kodi
+ 
 RUN \
  echo "**** fetch source and apply any patches if required ****" && \
  mkdir -p \
 	/tmp/kodi-source/build && \
+ echo "**** download ${KODI_VER}-${KODI_NAME}.tar.gz ****" && \
  curl -o \
  /tmp/kodi.tar.gz -L \
 	"https://github.com/xbmc/xbmc/archive/${KODI_VER}-${KODI_NAME}.tar.gz" && \
  tar xf /tmp/kodi.tar.gz -C \
 	/tmp/kodi-source --strip-components=1 && \
  cd /tmp/kodi-source && \
- git apply \
-	/patches/"${KODI_NAME}"/headless.patch
+ patch -p1 \
+	< /patches/"${KODI_NAME}"/headless.patch
 
 RUN \
  echo "**** compile kodi ****" && \
  cd /tmp/kodi-source/build && \
- cmake ../project/cmake/ \
+ cmake ../. \
 	-DCMAKE_INSTALL_LIBDIR=/usr/lib \
 	-DCMAKE_INSTALL_PREFIX=/usr \
 	-DENABLE_AIRTUNES=OFF \
@@ -106,12 +52,15 @@ RUN \
 	-DENABLE_CEC=OFF \
 	-DENABLE_DBUS=OFF \
 	-DENABLE_DVDCSS=OFF \
+	-DENABLE_GLX=OFF \
 	-DENABLE_LIBUSB=OFF \
 	-DENABLE_NFS=ON \
 	-DENABLE_NONFREE=OFF \
+	-DENABLE_OPENGL=OFF \
 	-DENABLE_OPTICAL=OFF \
 	-DENABLE_PULSEAUDIO=OFF \
 	-DENABLE_SDL=OFF \
+	-DENABLE_SNDIO=OFF \
 	-DENABLE_SSH=ON \
 	-DENABLE_UDEV=OFF \
 	-DENABLE_UPNP=ON \
@@ -123,27 +72,40 @@ RUN \
 RUN \
  echo "**** install kodi-send ****" && \
  install -Dm755 \
-	/tmp/kodi-source/tools/EventClients/Clients/Kodi\ Send/kodi-send.py \
+	/tmp/kodi-source/tools/EventClients/Clients/KodiSend/kodi-send.py \
 	/usr/bin/kodi-send && \
  install -Dm644 \
 	/tmp/kodi-source/tools/EventClients/lib/python/xbmcclient.py \
 	/usr/lib/python2.7/xbmcclient.py
 
-############## runtime stage ##############
+############### runtime ###################
 FROM lsiobase/ubuntu:bionic
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="sinopsyHK"
+
+# package versions
+# set KODI_REPO to "ppa" for stable repo and "unstable" for unstable.
+ARG KODI_REPO="ppa"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
 ENV HOME="/config"
 
 RUN \
- echo "**** install runtime packages ****" && \
+ echo "**** install gnupg ****" && \
+ apt-get update && \
+ apt-get install -y \
+	gnupg && \
+ echo "add kodi repository ****" && \
+ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 91E7EE5E && \
+ echo "deb http://ppa.launchpad.net/team-xbmc/${KODI_REPO}/ubuntu bionic main" >> \
+	/etc/apt/sources.list.d/kodi.list && \
+ echo "deb-src http://ppa.launchpad.net/team-xbmc/${KODI_REPO}/ubuntu bionic main" >> \
+	/etc/apt/sources.list.d/kodi.list && \
  apt-get update && \
  apt-get install -y \
 	--no-install-recommends \
@@ -153,8 +115,10 @@ RUN \
 	libegl1-mesa \
 	libfreetype6 \
 	libfribidi0 \
+	libfstrcmp0 \
 	libglew2.0 \
 	liblcms2-2 \
+	liblirc-dev \
 	liblzo2-2 \
 	libmicrohttpd12 \
 	libmysqlclient20 \
@@ -175,14 +139,14 @@ RUN \
 	libyajl2 \
 	python && \
  echo "**** cleanup ****" && \
- apt-get clean && \
  rm -rf \
 	/tmp/* \
-	/var/lib/apt/lists/* \
+	/var/lib/apt/lists/* \ 
 	/var/tmp/*
 
-# copy local files and buildstage artifacts
+# copy local files
 COPY root/ /
+# copy local files and buildstage artifacts
 COPY --from=buildstage /tmp/kodi-build/usr/ /usr/
 COPY --from=buildstage /usr/bin/kodi-send /usr/bin/kodi-send
 COPY --from=buildstage /usr/lib/python2.7/xbmcclient.py /usr/lib/python2.7/xbmcclient.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ FROM lsiobase/ubuntu:bionic as buildstage
 ARG KODI_NAME="Leia"
 ARG KODI_VER="18.1"
 
-### synology workaround ###
-ENV KODI_NAME=$KODI_NAME
-ENV KODI_VER=$KODI_VER
-
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
 

--- a/patches/Leia/headless.patch
+++ b/patches/Leia/headless.patch
@@ -1,0 +1,867 @@
+diff --git a/xbmc/AppParamParser.cpp b/xbmc/AppParamParser.cpp
+index 63920101d0a8..d1daa4618734 100644
+--- a/xbmc/AppParamParser.cpp
++++ b/xbmc/AppParamParser.cpp
+@@ -54,6 +54,7 @@ void CAppParamParser::DisplayHelp()
+   printf("Arguments:\n");
+   printf("  -fs\t\t\tRuns %s in full screen\n", CSysInfo::GetAppName().c_str());
+   printf("  --standalone\t\t%s runs in a stand alone environment without a window \n", CSysInfo::GetAppName().c_str());
++  printf("  --headless\t\t%s runs in headless mode without a window \n", CSysInfo::GetAppName().c_str());
+   printf("\t\t\tmanager and supporting applications. For example, that\n");
+   printf("\t\t\tenables network settings.\n");
+   printf("  -p or --portable\t%s will look for configurations in install folder instead of ~/.%s\n", CSysInfo::GetAppName().c_str(), lcAppName.c_str());
+@@ -75,6 +76,8 @@ void CAppParamParser::ParseArg(const std::string &arg)
+     DisplayVersion();
+   else if (arg == "--standalone")
+     m_standAlone = true;
++  else if (arg == "--headless")
++    m_headLess = true;
+   else if (arg == "-p" || arg  == "--portable")
+     m_platformDirectories = false;
+   else if (arg == "--debug")
+diff --git a/xbmc/AppParamParser.h b/xbmc/AppParamParser.h
+index a0823364e5ca..dbb3509fd88d 100644
+--- a/xbmc/AppParamParser.h
++++ b/xbmc/AppParamParser.h
+@@ -30,6 +30,7 @@ class CAppParamParser
+   bool m_platformDirectories = true;
+   bool m_testmode = false;
+   bool m_standAlone = false;
++  bool m_headLess = false;
+ 
+ private:
+   void ParseArg(const std::string &arg);
+diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
+old mode 100644
+new mode 100755
+index 1a6b8fa3aa3b..5b464d562d72
+--- a/xbmc/Application.cpp
++++ b/xbmc/Application.cpp
+@@ -367,6 +367,7 @@ bool CApplication::Create(const CAppParamParser &params)
+   m_bPlatformDirectories = params.m_platformDirectories;
+   m_bTestMode = params.m_testmode;
+   m_bStandalone = params.m_standAlone;
++  m_bHeadless = params.m_headLess;
+ 
+   m_pSettingsComponent.reset(new CSettingsComponent());
+   m_pSettingsComponent->Init(params);
+@@ -561,7 +562,7 @@ bool CApplication::Create(const CAppParamParser &params)
+   m_pAppPort = std::make_shared<CAppInboundProtocol>(*this);
+   CServiceBroker::RegisterAppPort(m_pAppPort);
+ 
+-  m_pWinSystem = CWinSystemBase::CreateWinSystem();
++  m_pWinSystem = CWinSystemBase::CreateWinSystem(!m_bHeadless);
+   CServiceBroker::RegisterWinSystem(m_pWinSystem.get());
+ 
+   if (!m_ServiceManager->InitStageTwo(params, m_pSettingsComponent->GetProfileManager()->GetProfileUserDataFolder()))
+@@ -608,7 +609,7 @@ bool CApplication::CreateGUI()
+ {
+   m_frameMoveGuard.lock();
+ 
+-  m_renderGUI = true;
++  m_renderGUI = !m_bHeadless;
+ 
+   if (!CServiceBroker::GetWinSystem()->InitWindowSystem())
+   {
+@@ -762,7 +763,7 @@ bool CApplication::Initialize()
+   // Init DPMS, before creating the corresponding setting control.
+   m_dpms.reset(new DPMSSupport());
+   bool uiInitializationFinished = false;
+-  if (CServiceBroker::GetGUI()->GetWindowManager().Initialized())
++  if (!m_bHeadless && CServiceBroker::GetGUI()->GetWindowManager().Initialized())
+   {
+     const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+     settings->GetSetting(CSettings::SETTING_POWERMANAGEMENT_DISPLAYSOFF)->SetRequirementsMet(m_dpms->IsSupported());
+@@ -873,9 +874,12 @@ bool CApplication::Initialize()
+ 
+   CLog::Log(LOGNOTICE, "initialize done");
+ 
+-  CheckOSScreenSaverInhibitionSetting();
+-  // reset our screensaver (starts timers etc.)
+-  ResetScreenSaver();
++  if (!m_bHeadless)
++  {
++    CheckOSScreenSaverInhibitionSetting();
++    // reset our screensaver (starts timers etc.)
++    ResetScreenSaver();
++  }
+ 
+   // if the user interfaces has been fully initialized let everyone know
+   if (uiInitializationFinished)
+diff --git a/xbmc/Application.h b/xbmc/Application.h
+index 30cf6e7d3246..4cebb7703e04 100644
+--- a/xbmc/Application.h
++++ b/xbmc/Application.h
+@@ -309,6 +309,7 @@ friend class CAppInboundProtocol;
+ 
+   bool PlatformDirectoriesEnabled() { return m_bPlatformDirectories; }
+   bool IsStandAlone() { return m_bStandalone; }
++  bool IsHeadLess() { return m_bHeadless; }
+   bool IsEnableTestMode() { return m_bTestMode; }
+ 
+   bool IsAppFocused() const { return m_AppFocused; }
+@@ -439,6 +440,7 @@ friend class CAppInboundProtocol;
+   bool m_skipGuiRender = false;
+ 
+   bool m_bStandalone = false;
++  bool m_bHeadless = false;
+   bool m_bTestMode = false;
+   bool m_bSystemScreenSaverEnable = false;
+ 
+diff --git a/xbmc/platform/xbmc.cpp b/xbmc/platform/xbmc.cpp
+old mode 100644
+new mode 100755
+diff --git a/xbmc/windowing/CMakeLists.txt b/xbmc/windowing/CMakeLists.txt
+old mode 100644
+new mode 100755
+index 1904e2c0ff38..16267bb759b7
+--- a/xbmc/windowing/CMakeLists.txt
++++ b/xbmc/windowing/CMakeLists.txt
+@@ -1,13 +1,15 @@
+ set(SOURCES GraphicContext.cpp
+             OSScreenSaver.cpp
+             Resolution.cpp
+-            WinSystem.cpp)
++            WinSystem.cpp
++            WinSystemHeadless.cpp)
+ 
+ set(HEADERS GraphicContext.h
+             OSScreenSaver.h
+             Resolution.h
+             WinEvents.h
+             WinSystem.h
++            WinSystemHeadless.h
+             XBMC_events.h
+             VideoSync.h)
+ 
+diff --git a/xbmc/windowing/WinSystem.h b/xbmc/windowing/WinSystem.h
+old mode 100644
+new mode 100755
+index 6e84c49e5fd5..aabd4529d7eb
+--- a/xbmc/windowing/WinSystem.h
++++ b/xbmc/windowing/WinSystem.h
+@@ -40,7 +40,7 @@ class CWinSystemBase
+   CWinSystemBase();
+   virtual ~CWinSystemBase();
+ 
+-  static std::unique_ptr<CWinSystemBase> CreateWinSystem();
++  static std::unique_ptr<CWinSystemBase> CreateWinSystem(bool render);
+ 
+   // Access render system interface
+   virtual CRenderSystemBase *GetRenderSystem() { return nullptr; }
+diff --git a/xbmc/windowing/WinSystemHeadless.cpp b/xbmc/windowing/WinSystemHeadless.cpp
+new file mode 100755
+index 000000000000..3f057f78fc13
+--- /dev/null
++++ b/xbmc/windowing/WinSystemHeadless.cpp
+@@ -0,0 +1,57 @@
++/*
++ *  Copyright (C) 2005-2018 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#include "WinSystemHeadless.h"
++
++#include "utils/log.h"
++
++#include <vector>
++#include <string>
++
++//using namespace KODI::MESSAGING;
++using namespace KODI::WINDOWING;
++
++#define EGL_NO_CONFIG (EGLConfig)0
++
++CWinSystemHeadless::CWinSystemHeadless() : CWinSystemBase(), CRenderSystemBase()
++{
++}
++
++CWinSystemHeadless::~CWinSystemHeadless() = default;
++
++// bool CWinSystemHeadless::MessagePump()
++// {
++//   return m_winEvents->MessagePump();
++// }
++
++bool CWinSystemHeadless::InitWindowSystem() {return true;};
++bool CWinSystemHeadless::DestroyWindowSystem() {return true;};
++bool CWinSystemHeadless::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) {return true;};
++bool CWinSystemHeadless::DestroyWindow() {return true;};
++bool CWinSystemHeadless::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) {return true;};
++void CWinSystemHeadless::FinishWindowResize(int newWidth, int newHeight) {};
++bool CWinSystemHeadless::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) {return true;};
++void CWinSystemHeadless::UpdateResolutions() {};
++void CWinSystemHeadless::ShowOSMouse(bool show) {};
++
++void CWinSystemHeadless::NotifyAppActiveChange(bool bActivated) {};
++void CWinSystemHeadless::NotifyAppFocusChange(bool bGaining) {};
++
++bool CWinSystemHeadless::Minimize() {return true;};
++bool CWinSystemHeadless::Restore() {return true;};
++bool CWinSystemHeadless::Hide() {return true;};
++bool CWinSystemHeadless::Show(bool raise) {return true;};
++void CWinSystemHeadless::Register(IDispResource *resource) {};
++void CWinSystemHeadless::Unregister(IDispResource *resource) {};
++bool CWinSystemHeadless::HasCalibration(const RESOLUTION_INFO &resInfo) {return true;};
++bool CWinSystemHeadless::UseLimitedColor() {return true;};
++
++void CWinSystemHeadless::ShowSplash(const std::string& message)
++{
++  CLog::Log(LOGDEBUG, message.c_str());
++};
+diff --git a/xbmc/windowing/WinSystemHeadless.h b/xbmc/windowing/WinSystemHeadless.h
+new file mode 100755
+index 000000000000..839fb0982679
+--- /dev/null
++++ b/xbmc/windowing/WinSystemHeadless.h
+@@ -0,0 +1,78 @@
++/*
++ *  Copyright (C) 2005-2018 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#pragma once
++
++#include "rendering/RenderSystem.h"
++#include "WinSystem.h"
++
++#include <string>
++#include <vector>
++
++
++class CWinSystemHeadless : public CWinSystemBase, public CRenderSystemBase
++{
++public:
++  CWinSystemHeadless();
++  ~CWinSystemHeadless() override;
++
++  // CWinSystemBase
++  CRenderSystemBase *GetRenderSystem() override { return this; }
++  bool InitWindowSystem() override;
++  bool DestroyWindowSystem() override;
++  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
++  bool DestroyWindow() override;
++  bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
++  void FinishWindowResize(int newWidth, int newHeight) override;
++  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
++  void UpdateResolutions() override;
++  void ShowOSMouse(bool show) override;
++
++  void NotifyAppActiveChange(bool bActivated) override;
++  void NotifyAppFocusChange(bool bGaining) override;
++
++  bool Minimize() override;
++  bool Restore() override;
++  bool Hide() override;
++  bool Show(bool raise = true) override;
++  void Register(IDispResource *resource) override;
++  void Unregister(IDispResource *resource) override;
++  bool HasCalibration(const RESOLUTION_INFO &resInfo) override;
++  bool UseLimitedColor() override;
++
++  // winevents override
++  //bool MessagePump() override;
++
++  // render
++  bool InitRenderSystem() override { return true;} ;
++  bool DestroyRenderSystem() override { return true;} ;
++  bool ResetRenderSystem(int width, int height) override { return true;} ;
++
++  bool BeginRender() override { return true;} ;
++  bool EndRender() override { return true;} ;
++  void PresentRender(bool rendered, bool videoLayer) override {} ;
++  bool ClearBuffers(UTILS::Color color) override { return true;} ;
++  bool IsExtSupported(const char* extension) const override { return false;} ;
++
++  void SetViewPort(const CRect& viewPort) override {} ;
++  void GetViewPort(CRect& viewPort) override {} ;
++
++  void SetScissors(const CRect &rect) override {} ;
++  void ResetScissors() override {} ;
++
++  void CaptureStateBlock() override {} ;
++  void ApplyStateBlock() override {} ;
++
++  void SetCameraPosition(const CPoint &camera, int screenWidth, int screenHeight, float stereoFactor = 0.f) override {} ;
++  void ShowSplash(const std::string& message) override;
++
++protected:
++
++private:
++
++};
+diff --git a/xbmc/windowing/X11/CMakeLists.txt b/xbmc/windowing/X11/CMakeLists.txt
+old mode 100644
+new mode 100755
+index 282e96fa3457..c23ad4be8cb6
+--- a/xbmc/windowing/X11/CMakeLists.txt
++++ b/xbmc/windowing/X11/CMakeLists.txt
+@@ -4,6 +4,7 @@ set(SOURCES GLContextEGL.cpp
+             OSScreenSaverX11.cpp
+             WinEventsX11.cpp
+             WinSystemX11.cpp
++            WinSystemHeadlessX11.cpp
+             WinSystemX11GLContext.cpp
+             XRandR.cpp
+             VideoSyncOML.cpp)
+@@ -14,6 +15,7 @@ set(HEADERS GLContext.h
+             OSScreenSaverX11.h
+             WinEventsX11.h
+             WinSystemX11.h
++            WinSystemHeadlessX11.h
+             WinSystemX11GLContext.h
+             XRandR.h
+             VideoSyncOML.h)
+diff --git a/xbmc/windowing/X11/WinSystemHeadlessX11.cpp b/xbmc/windowing/X11/WinSystemHeadlessX11.cpp
+new file mode 100755
+index 000000000000..3eb5681051a4
+--- /dev/null
++++ b/xbmc/windowing/X11/WinSystemHeadlessX11.cpp
+@@ -0,0 +1,50 @@
++/*
++ *  Copyright (C) 2005-2018 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#include "WinSystemHeadlessX11.h"
++#include "utils/log.h"
++#include <vector>
++#include <string>
++
++//using namespace KODI::MESSAGING;
++using namespace KODI::WINDOWING;
++
++CWinSystemHeadlessX11::CWinSystemHeadlessX11() : 
++  CWinSystemX11(),
++  CRenderSystemBase()
++{
++}
++
++CWinSystemHeadlessX11::~CWinSystemHeadlessX11() = default;
++
++bool CWinSystemHeadlessX11::InitWindowSystem() {return true;};
++bool CWinSystemHeadlessX11::DestroyWindowSystem() {return true;};
++bool CWinSystemHeadlessX11::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) {return true;};
++bool CWinSystemHeadlessX11::DestroyWindow() {return true;};
++bool CWinSystemHeadlessX11::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) {return true;};
++void CWinSystemHeadlessX11::FinishWindowResize(int newWidth, int newHeight) {};
++bool CWinSystemHeadlessX11::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) {return true;};
++void CWinSystemHeadlessX11::UpdateResolutions() {};
++void CWinSystemHeadlessX11::ShowOSMouse(bool show) {};
++
++void CWinSystemHeadlessX11::NotifyAppActiveChange(bool bActivated) {};
++void CWinSystemHeadlessX11::NotifyAppFocusChange(bool bGaining) {};
++
++bool CWinSystemHeadlessX11::Minimize() {return true;};
++bool CWinSystemHeadlessX11::Restore() {return true;};
++bool CWinSystemHeadlessX11::Hide() {return true;};
++bool CWinSystemHeadlessX11::Show(bool raise) {return true;};
++void CWinSystemHeadlessX11::Register(IDispResource *resource) {};
++void CWinSystemHeadlessX11::Unregister(IDispResource *resource) {};
++bool CWinSystemHeadlessX11::HasCalibration(const RESOLUTION_INFO &resInfo) {return true;};
++bool CWinSystemHeadlessX11::UseLimitedColor() {return true;};
++
++void CWinSystemHeadlessX11::ShowSplash(const std::string& message)
++{
++  CLog::Log(LOGDEBUG, message.c_str());
++};
+diff --git a/xbmc/windowing/X11/WinSystemHeadlessX11.h b/xbmc/windowing/X11/WinSystemHeadlessX11.h
+new file mode 100755
+index 000000000000..c77aa9a1c143
+--- /dev/null
++++ b/xbmc/windowing/X11/WinSystemHeadlessX11.h
+@@ -0,0 +1,81 @@
++/*
++ *  Copyright (C) 2005-2018 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#pragma once
++
++#include "windowing/WinSystemHeadless.h"
++#include "WinSystemX11.h"
++
++#include <string>
++#include <vector>
++
++class CWinSystemHeadlessX11 : public CWinSystemX11, public CRenderSystemBase
++{
++public:
++  CWinSystemHeadlessX11();
++  ~CWinSystemHeadlessX11() override;
++
++  // CWinSystemBase
++  CRenderSystemBase *GetRenderSystem() override { return this; }
++  bool InitWindowSystem() override;
++  bool DestroyWindowSystem() override;
++  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
++  bool DestroyWindow() override;
++  bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
++  void FinishWindowResize(int newWidth, int newHeight) override;
++  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
++  void UpdateResolutions() override;
++  void ShowOSMouse(bool show) override;
++
++  void NotifyAppActiveChange(bool bActivated) override;
++  void NotifyAppFocusChange(bool bGaining) override;
++
++  bool Minimize() override;
++  bool Restore() override;
++  bool Hide() override;
++  bool Show(bool raise = true) override;
++  void Register(IDispResource *resource) override;
++  void Unregister(IDispResource *resource) override;
++  bool HasCalibration(const RESOLUTION_INFO &resInfo) override;
++  bool UseLimitedColor() override;
++
++  // winevents override
++  //bool MessagePump() override;
++
++  // render
++  bool InitRenderSystem() override { return true;} ;
++  bool DestroyRenderSystem() override { return true;} ;
++  bool ResetRenderSystem(int width, int height) override { return true;} ;
++
++  bool BeginRender() override { return true;} ;
++  bool EndRender() override { return true;} ;
++  void PresentRender(bool rendered, bool videoLayer) override {} ;
++  bool ClearBuffers(UTILS::Color color) override { return true;} ;
++  bool IsExtSupported(const char* extension) const override { return false;} ;
++
++  void SetViewPort(const CRect& viewPort) override {} ;
++  void GetViewPort(CRect& viewPort) override {} ;
++
++  void SetScissors(const CRect &rect) override {} ;
++  void ResetScissors() override {} ;
++
++  void CaptureStateBlock() override {} ;
++  void ApplyStateBlock() override {} ;
++
++  void SetCameraPosition(const CPoint &camera, int screenWidth, int screenHeight, float stereoFactor = 0.f) override {} ;
++  void ShowSplash(const std::string& message) override;
++
++  // CWinSystemX11
++  virtual bool SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate = NULL) override {return true;};
++  virtual XVisualInfo* GetVisual() override {return (XVisualInfo*) nullptr;};
++
++protected:
++
++private:
++
++};
+diff --git a/xbmc/windowing/X11/WinSystemX11GLContext.cpp b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+old mode 100644
+new mode 100755
+index 5b0b155736b9..b454ffd9cc60
+--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
++++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+@@ -9,6 +9,7 @@
+ #include <X11/Xlib.h>
+ #include <X11/Xutil.h>
+ 
++#include "WinSystemHeadlessX11.h"
+ #include "WinSystemX11GLContext.h"
+ #include "GLContextEGL.h"
+ #include "utils/log.h"
+@@ -32,9 +33,13 @@
+ 
+ using namespace KODI;
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemX11GLContext());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemX11GLContext());
++  else
++    winSystem.reset(new CWinSystemHeadlessX11());
+   return winSystem;
+ }
+ 
+diff --git a/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp b/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
+old mode 100644
+new mode 100755
+index 076f7718f0d1..43ff6da6a935
+--- a/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
++++ b/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
+@@ -7,13 +7,21 @@
+  */
+ 
+ #include "VideoSyncAML.h"
++#include "windowing/WinSystemHeadless.h"
+ #include "WinSystemAmlogicGLESContext.h"
+ #include "utils/log.h"
+ #include "threads/SingleLock.h"
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemAmlogicGLESContext());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemAmlogicGLESContext());
++  else
++  {
++    winSystem.reset(new CWinSystemHeadless());
++    CLog::Log(LOGWARNING, "HEADLESS MOD NOT TESTED ON THIS BUILD");
++  }
+   return winSystem;
+ }
+ 
+diff --git a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+old mode 100644
+new mode 100755
+index db326d62ae60..b163038673eb
+--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
++++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+@@ -7,14 +7,22 @@
+  */
+ 
+ #include "VideoSyncAndroid.h"
++#include "windowing/WinSystemHeadless.h"
+ #include "WinSystemAndroidGLESContext.h"
+ #include "utils/log.h"
+ #include "threads/SingleLock.h"
+ #include "platform/android/activity/XBMCApp.h"
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemAndroidGLESContext());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemAndroidGLESContext());
++  else
++  {
++    winSystem.reset(new CWinSystemHeadless());
++    CLog::Log(LOGWARNING, "HEADLESS MOD NOT TESTED ON THIS BUILD");
++  }
+   return winSystem;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+old mode 100644
+new mode 100755
+index 7dc31f3fb361..1eb92acbb986
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -14,6 +14,7 @@
+ #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+ #include "EGL/egl.h"
+ #include "EGL/eglext.h"
++#include "windowing/WinSystemHeadless.h"
+ #include "WinSystemGbmGLContext.h"
+ #include "OptionalsReg.h"
+ #include "platform/linux/XTimeUtils.h"
+@@ -25,9 +26,13 @@ CWinSystemGbmGLContext::CWinSystemGbmGLContext()
+ : CWinSystemGbmEGLContext(EGL_PLATFORM_GBM_MESA, "EGL_MESA_platform_gbm")
+ {}
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemGbmGLContext());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemGbmGLContext());
++  else
++    winSystem.reset(new CWinSystemHeadless());
+   return winSystem;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+old mode 100644
+new mode 100755
+index c24cb919aec9..a5ad5ed2e985
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -20,6 +20,7 @@
+ #include "OptionalsReg.h"
+ #include "platform/linux/XTimeUtils.h"
+ #include "utils/log.h"
++#include "windowing/WinSystemHeadless.h"
+ #include "WinSystemGbmGLESContext.h"
+ 
+ #include <gbm.h>
+@@ -32,9 +33,13 @@ CWinSystemGbmGLESContext::CWinSystemGbmGLESContext()
+ : CWinSystemGbmEGLContext(EGL_PLATFORM_GBM_MESA, "EGL_MESA_platform_gbm")
+ {}
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemGbmGLESContext());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if render
++    winSystem.reset( new CWinSystemGbmGLESContext());
++  else
++    winSystem.reset( new CWinSystemHeadless());
+   return winSystem;
+ }
+ 
+diff --git a/xbmc/windowing/osx/WinSystemIOS.mm b/xbmc/windowing/osx/WinSystemIOS.mm
+old mode 100644
+new mode 100755
+index 7f849ba31282..a889e4fe66e3
+--- a/xbmc/windowing/osx/WinSystemIOS.mm
++++ b/xbmc/windowing/osx/WinSystemIOS.mm
+@@ -7,6 +7,7 @@
+  */
+ 
+ #include "VideoSyncIos.h"
++#include "windowing/WinSystemHeadless.h"
+ #include "WinEventsIOS.h"
+ #include "WinSystemIOS.h"
+ #include "cores/AudioEngine/Sinks/AESinkDARWINIOS.h"
+@@ -63,9 +64,16 @@ - (void) runDisplayLink;
+   IOSDisplayLinkCallback *callbackClass;
+ };
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemIOS());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemIOS());
++  else
++  {
++    winSystem.reset(new CWinSystemHeadless());
++    CLog::Log(LOGWARNING, "HEADLESS MOD NOT TESTED ON THIS BUILD");
++  }
+   return winSystem;
+ }
+ 
+diff --git a/xbmc/windowing/osx/WinSystemOSXGL.mm b/xbmc/windowing/osx/WinSystemOSXGL.mm
+old mode 100644
+new mode 100755
+index 9ec4ffe49e30..67ace5a2c1a6
+--- a/xbmc/windowing/osx/WinSystemOSXGL.mm
++++ b/xbmc/windowing/osx/WinSystemOSXGL.mm
+@@ -7,15 +7,23 @@
+  */
+ 
+ #include "guilib/Texture.h"
++#include "windowing/WinSystemHeadless.h"
+ #include "WinSystemOSXGL.h"
+ #include "rendering/gl/RenderSystemGL.h"
+ 
+ 
+ //------------------------------------------------------------------------------
+ //------------------------------------------------------------------------------
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemOSXGL());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemOSXGL());
++  else
++  {
++    winSystem.reset(new CWinSystemHeadless());
++    CLog::Log(LOGWARNING, "HEADLESS MOD NOT TESTED ON THIS BUILD");
++  }
+   return winSystem;
+ }
+ 
+diff --git a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+old mode 100644
+new mode 100755
+index a949c85e8b35..8689c178f703
+--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
++++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+@@ -8,6 +8,7 @@
+ 
+ #include "Application.h"
+ #include "VideoSyncPi.h"
++#include "windowing/WinSystemHeadless.h"
+ #include "WinSystemRpiGLESContext.h"
+ #include "guilib/GUIComponent.h"
+ #include "guilib/GUIWindowManager.h"
+@@ -24,9 +25,16 @@
+ using namespace KODI;
+ 
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemRpiGLESContext());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemRpiGLESContext());
++  else
++  {
++    winSystem.reset(new CWinSystemHeadless());
++    CLog::Log(LOGWARNING, "HEADLESS MOD NOT TESTED ON THIS BUILD");
++  }
+   return winSystem;
+ }
+ 
+diff --git a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+old mode 100644
+new mode 100755
+index 9d5f0e3d9e56..dbbe558d57c8
+--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
++++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+@@ -6,6 +6,7 @@
+  *  See LICENSES/README.md for more information.
+  */
+ 
++#include "windowing/WinSystemHeadless.h"
+ #include "WinSystemWaylandEGLContextGL.h"
+ #include "OptionalsReg.h"
+ 
+@@ -19,9 +20,16 @@
+ 
+ using namespace KODI::WINDOWING::WAYLAND;
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemWaylandEGLContextGL());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemWaylandEGLContextGL());
++  else
++  {
++    winSystem.reset(new CWinSystemHeadless());
++    CLog::Log(LOGWARNING, "HEADLESS MOD NOT TESTED ON THIS BUILD");
++  }
+   return winSystem;
+ }
+ 
+diff --git a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
+old mode 100644
+new mode 100755
+index dc7de3e8ab65..4dfb15b8f746
+--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
++++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
+@@ -6,6 +6,7 @@
+  *  See LICENSES/README.md for more information.
+  */
+ 
++#include "windowing/WinSystemHeadless.h"
+ #include "WinSystemWaylandEGLContextGLES.h"
+ #include "OptionalsReg.h"
+ 
+@@ -19,9 +20,16 @@
+ 
+ using namespace KODI::WINDOWING::WAYLAND;
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemWaylandEGLContextGLES());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemWaylandEGLContextGLES());
++  else
++  {
++    winSystem.reset(new CWinSystemHeadless());
++    CLog::Log(LOGWARNING, "HEADLESS MOD NOT TESTED ON THIS BUILD");
++  }
+   return winSystem;
+ }
+ 
+diff --git a/xbmc/windowing/win10/WinSystemWin10DX.cpp b/xbmc/windowing/win10/WinSystemWin10DX.cpp
+old mode 100644
+new mode 100755
+index 2ac39b1d818f..c8fdf151535f
+--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
++++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
+@@ -10,11 +10,20 @@
+ #include "input/touch/generic/GenericTouchInputHandler.h"
+ #include "rendering/dx/DirectXHelper.h"
+ #include "utils/log.h"
++#include "windowing/WinSystemHeadless.h"
+ #include "WinSystemWin10DX.h"
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  return std::make_unique<CWinSystemWin10DX>();
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemWin10DX());
++  else
++  {
++    winSystem.reset(new CWinSystemHeadless());
++    CLog::Log(LOGWARNING, "HEADLESS MOD NOT TESTED ON THIS BUILD");
++  }
++  return winSystem;
+ }
+ 
+ CWinSystemWin10DX::CWinSystemWin10DX() : CRenderSystemDX()
+diff --git a/xbmc/windowing/windows/WinSystemWin32DX.cpp b/xbmc/windowing/windows/WinSystemWin32DX.cpp
+old mode 100644
+new mode 100755
+index 2270a65000f0..17fdb5ebca97
+--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
++++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
+@@ -6,6 +6,7 @@
+  *  See LICENSES/README.md for more information.
+  */
+ 
++#include "windowing/WinSystemHeadless.h"
+ #include "WinSystemWin32DX.h"
+ #include "commons/ilog.h"
+ #include "platform/win32/CharsetConverter.h"
+@@ -40,9 +41,16 @@ static PFND3D10DDI_OPENADAPTER s_fnOpenAdapter10_2{ nullptr };
+ static PFND3D10DDI_CREATEDEVICE s_fnCreateDeviceOrig{ nullptr };
+ static PFND3D10DDI_CREATERESOURCE s_fnCreateResourceOrig{ nullptr };
+ 
+-std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
++std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem(bool render)
+ {
+-  std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemWin32DX());
++  std::unique_ptr<CWinSystemBase> winSystem(nullptr);
++  if (render)
++    winSystem.reset(new CWinSystemWin32DX());
++  else
++  {
++    winSystem.reset(new CWinSystemHeadless());
++    CLog::Log(LOGWARNING, "HEADLESS MOD NOT TESTED ON THIS BUILD");
++  }
+   return winSystem;
+ }
+ 
+
+From b1d64fecc48e405cb2eaa9050262fdf1b8289efe Mon Sep 17 00:00:00 2001
+From: sinopsysHK <sinofwd@gmail.com>
+Date: Sun, 3 Mar 2019 03:25:05 +0800
+Subject: [PATCH 2/2] update manpage
+
+---
+ docs/manpages/kodi.bin.1 | 3 +++
+ 1 file changed, 3 insertions(+)
+ mode change 100644 => 100755 docs/manpages/kodi.bin.1
+
+diff --git a/docs/manpages/kodi.bin.1 b/docs/manpages/kodi.bin.1
+old mode 100644
+new mode 100755
+index 80ef889212d3..3cb366e2598d
+--- a/docs/manpages/kodi.bin.1
++++ b/docs/manpages/kodi.bin.1
+@@ -17,6 +17,9 @@ Kodi runs in a stand alone environment without a window
+ manager and supporting applications. For example, that
+ enables network settings.
+ .TP
++\fB\-\-headless\fR
++Kodi runs as a back-end server without any display.
++.TP
+ \fB\-p\fR or \fB\-\-portable\fR
+ Kodi will look for configurations in install folder instead of ~/.kodi
+ .TP

--- a/root/etc/services.d/kodi/run
+++ b/root/etc/services.d/kodi/run
@@ -2,4 +2,4 @@
 
 	s6-setuidgid abc \
 	/usr/bin/kodi --headless \
-	> /config/.kodi/kodi.output.log 2>&1
+	> /config/.kodi/kodi.screen_output.log 2>&1

--- a/root/etc/services.d/kodi/run
+++ b/root/etc/services.d/kodi/run
@@ -1,2 +1,5 @@
 #!/usr/bin/with-contenv bash
-s6-setuidgid abc /usr/lib/kodi/kodi.bin --headless
+
+	s6-setuidgid abc \
+	/usr/bin/kodi --headless --debug \
+	> /config/.kodi/kodi.output.log 2>&1

--- a/root/etc/services.d/kodi/run
+++ b/root/etc/services.d/kodi/run
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv bash
 
 	s6-setuidgid abc \
-	/usr/bin/kodi --headless --debug \
+	/usr/bin/kodi --headless \
 	> /config/.kodi/kodi.output.log 2>&1


### PR DESCRIPTION
Create a real kodi headless with no resource hit due to offscreen GUI management and no runtime dependency on any renderer or X server.

Remediate to #87 

Based on PR: https://github.com/xbmc/xbmc/pull/15652

This patch is not going to be integrated in Kodi mainstream codebase as it is not too hacky and not respectfull to target architecture.

Tested on my NAS for few days: working perfectly with 0% CPU used when idle (not scanning) against >30-40% with baseline version relying on xpra

Notice: I had to make some hacks in Dockerfile to have successful build on my Synology (refering to https://gist.github.com/agross/614b3c85dcc152e258403f4c5d4273b7)

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

