### PR TITLE
Bump Kodi to 18.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM lsiobase/ubuntu:bionic as buildstage
 
 # package versions
 ARG KODI_NAME="Leia"
-ARG KODI_VER="18.5"
+ARG KODI_VER="18.7.1"
 
 # defines which addons to build
 ARG KODI_ADDONS="vfs.libarchive vfs.rar"

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -4,7 +4,7 @@ FROM lsiobase/ubuntu:arm64v8-bionic as buildstage
 
 # package versions
 ARG KODI_NAME="Leia"
-ARG KODI_VER="18.5"
+ARG KODI_VER="18.7.1"
 
 # defines which addons to build
 ARG KODI_ADDONS="vfs.libarchive vfs.rar"

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -4,7 +4,7 @@ FROM lsiobase/ubuntu:arm32v7-bionic as buildstage
 
 # package versions
 ARG KODI_NAME="Leia"
-ARG KODI_VER="18.5"
+ARG KODI_VER="18.7.1"
 
 # defines which addons to build
 ARG KODI_ADDONS="vfs.libarchive vfs.rar"


### PR DESCRIPTION
18.7.1 is the [latest release](https://github.com/xbmc/xbmc/releases/).

Currently testing whether it builds with this simple patch.